### PR TITLE
added enums for selecting bracketing method and unidirectional search

### DIFF
--- a/Optimizer/src/optimizer.h
+++ b/Optimizer/src/optimizer.h
@@ -61,7 +61,17 @@ double NewtonRapshon (std::function<double (double)> obj_func, Eigen::Vector2d r
     return x;
 }
 
-double SVOptimize (std::function<double (double)> obj_func, double x, std::string bracketing = "bound_phase", std::string unidir = "new_rap") {
+enum class BracketingMethod {
+  BOUND_PHASE
+};
+
+enum class UnidirectionalSearch {
+  NEW_RAP
+};
+
+double SVOptimize (std::function<double (double)> obj_func,
+                   double x, BracketingMethod bracketing_method = BracketingMethod::BOUND_PHASE,
+                   UnidirectionalSearch undirectional_search = UnidirectionalSearch::NEW_RAP) {
 // This function does the single variable optimzation
 // Input parameters are :
 // obj_func - The std::function variable containing our objective function


### PR DESCRIPTION
added enums for selecting bracketing method and unidirectional search type. This will make these parameters more extensible in the future and better documented (users won't have to search for the list of available strings, they can just look at the enum).

Fixes #31 